### PR TITLE
Spec run migration

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -11,25 +11,25 @@ Let's say that you have data for the same kind of measurement being repeated mul
 For example, you take a sample from your material, subdivide it 8 times, and perform the
 same measurement on each of those 8 sub-samples.
 The measurement that you are performing can be represented by a single
-[`MeasurementSpec`](../Specification/Objects/#measurement-spec)
+[`MeasurementSpec`](../specification/objects/#measurement-spec)
 and each of those 8 sub-samples as its own
-[`MeasurementRun`](../Specification/Objects/#measurement-run)
+[`MeasurementRun`](../specification/objects/#measurement-run)
 associated with that spec.
 Each
-[`MeasurementRun`](../Specification/Objects/#measurement-run)
+[`MeasurementRun`](../specification/objects/#measurement-run)
 is associated with the
-[`MatererialRun`](../Specification/Objects/#measurement-run)
+[`MatererialRun`](../specification/objects/#measurement-run)
 representing the material that you sampled and sub-divided.
 
 For each property in the
-[`MeasurementRun`](../Specification/Objects/#measurement-run)
+[`MeasurementRun`](../specification/objects/#measurement-run)
 objects, you may want to compute some statistics of the 8-sample distribution.
 For example: the mean and the standard deviation of each property and/or its minimum and maximum values.
 In the future, these statistics will be automatically computed on the Citrine platform.
 For now, you can compute them yourself and record them in another
-[`MeasurementRun`](../Specification/Objects/#measurement-run)
+[`MeasurementRun`](../specification/objects/#measurement-run)
 object distinct from the 8 samples.
 If there are multiple properties and/or multiple statistics, they should all go in the same `MeasurementRun`.
 The statistics should be
-[`Property`](../Specification/Attributes/#property)
+[`Property`](../specification/attributes/#property)
 attributes with their `origin` field set to `computed`.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,7 +1,7 @@
 # FAQ
 
 It's not you; it's us.
-Taurus is not a simple spec, and 
+Taurus is not a simple representation, and
 we frequently get questions about how to use it to represent certain kinds of data.
 This page attempts to answer some of those questions.
 
@@ -10,27 +10,26 @@ This page attempts to answer some of those questions.
 Let's say that you have data for the same kind of measurement being repeated multiple times.
 For example, you take a sample from your material, subdivide it 8 times, and perform the
 same measurement on each of those 8 sub-samples.
-The measurement that you are performing can be represented by a single 
-[`MeasurementSpec`](../Specification/Objects/#measurement-specification) 
-and each of those 8 sub-samples as its own 
-[`MeasurementRun`](../Specification/Objects/#measurement-run) 
+The measurement that you are performing can be represented by a single
+[`MeasurementSpec`](../Specification/Objects/#measurement-spec)
+and each of those 8 sub-samples as its own
+[`MeasurementRun`](../Specification/Objects/#measurement-run)
 associated with that spec.
 Each
-[`MeasurementRun`](../Specification/Objects/#measurement-run) 
-is associated with the 
-[`MatererialRun`](../Specification/Objects/#measurement-run) 
+[`MeasurementRun`](../Specification/Objects/#measurement-run)
+is associated with the
+[`MatererialRun`](../Specification/Objects/#measurement-run)
 representing the material that you sampled and sub-divided.
 
-For each property in the 
+For each property in the
 [`MeasurementRun`](../Specification/Objects/#measurement-run)
 objects, you may want to compute some statistics of the 8-sample distribution.
 For example: the mean and the standard deviation of each property and/or its minimum and maximum values.
 In the future, these statistics will be automatically computed on the Citrine platform.
 For now, you can compute them yourself and record them in another
-[`MeasurementRun`](../Specification/Objects/#measurement-run) 
+[`MeasurementRun`](../Specification/Objects/#measurement-run)
 object distinct from the 8 samples.
 If there are multiple properties and/or multiple statistics, they should all go in the same `MeasurementRun`.
-The statistics should be 
+The statistics should be
 [`Property`](../Specification/Attributes/#property)
 attributes with their `origin` field set to `computed`.
-

--- a/docs/high-level-overview.md
+++ b/docs/high-level-overview.md
@@ -31,15 +31,15 @@ Note, Ingredient Objects cannot be represented in the Template state.
 Object      | Examples   | Linked Objects | State | Possible Attributes
 ------------|------------|----------------|:-----:|--------------------
 `Material`  | Glass, H2O | n/a | Template  | Properties
-^      |      ^     | input: Process (1); Measurement (0 or many) | Specification | Properties and Conditions
+^      |      ^     | input: Process (1); Measurement (0 or many) | Spec | Properties and Conditions
 ^      |      ^     | ^ | Run | none
 `Process` | Gas pressure sintering, Binder burnout | n/a | Template | Parameters and Conditions
-^      |      ^     | input: Ingredient (0 or many); output: Material (1) | Specification | Parameters and Conditions
+^      |      ^     | input: Ingredient (0 or many); output: Material (1) | Spec | Parameters and Conditions
 ^      |      ^     | ^ | Run | Parameters and Conditions
 `Measurement` | 3 point bend, combustion analysis | n/a | Template | Properties, Parameters, and Conditions
-^      |      ^     | Material (1) |Specification | Parameters, and Conditions
+^      |      ^     | Material (1) |Spec | Parameters, and Conditions
 ^      |      ^     | ^ | Run | Properties, Parameters, and Conditions
-`Ingredient` |      80wt%, 20lbs, solute     | Material (1) |Specification | n/a
+`Ingredient` |      80wt%, 20lbs, solute     | Material (1) |Spec | n/a
 ^      |      ^     | ^ | Run | n/a
 
 *Table1:* Shows the relation of Objects to other Objects and Attributes possible in each state.
@@ -64,7 +64,7 @@ Taurus distinguishes between the generalization of what might be done (Template)
 
 > As an example, one can have a Template for a Process Object defined as “sinter at {temperature} for {time} in kiln {id}”.
 This would be the Template used for a Spec of a kiln process used in the production of alumina.
-The Specification of the Process object might be “sinter at 2400 K for 6 hours in kiln 14”.
+The Spec of the Process object might be “sinter at 2400 K for 6 hours in kiln 14”.
 The Process Run object would be what really happened when the process was conducted.
 For example, someone may have run the kiln and it ran at 2395 K.
 The Run of the Process object would be “sinter at 2395 K for 5.75 hours in kiln 14”.

--- a/docs/high-level-overview.md
+++ b/docs/high-level-overview.md
@@ -3,9 +3,9 @@
 ## How is data stored
 We have given this format the codename `taurus`.
 
-Taurus stores data via interconnected Data Objects, representing specifications and realizations of materials, processing steps, measurements, and ingredient information.
+Taurus stores data via interconnected Data Objects, representing Specs and Runs of Materials, Processing steps, Measurements, and Ingredient information.
 This format is graphical rather than tabular.
-It will support a JSON-based serialization, like the 
+It will support a JSON-based serialization, like the
 [PIF](http://citrineinformatics.github.io/pif-documentation/), but with links as references rather than nested objects (i.e. subsystems).
 Conversely, there are many new ideas that exist in taurus that are not captured by the PIF, including:
 
@@ -20,7 +20,7 @@ Conversely, there are many new ideas that exist in taurus that are not captured 
 There are four categories of Data Objects in Taurus: Materials, Processes, Measurements, and Ingredients.
 These represent real world objects in the development of materials.
 The 4 categories of Data Objects can only be linked in specific ways, for example, a Process Object can only be linked to one or many Material Objects as its input, more details are explained in Table1.
-Each Object can be represented in 3 different states, these states are defined below, they are Template, Specification, and Realization.
+Each Object can be represented in 3 different states, these states are defined below, they are Template, Spec, and Run.
 Note, Ingredient Objects cannot be represented in the Template state.
 
 * **Material Object:** Describes a material by a name used in an organization and optional notes to describe it.
@@ -32,15 +32,15 @@ Object      | Examples   | Linked Objects | State | Possible Attributes
 ------------|------------|----------------|:-----:|--------------------
 `Material`  | Glass, H2O | n/a | Template  | Properties
 ^      |      ^     | input: Process (1); Measurement (0 or many) | Specification | Properties and Conditions
-^      |      ^     | ^ | Realization | none
+^      |      ^     | ^ | Run | none
 `Process` | Gas pressure sintering, Binder burnout | n/a | Template | Parameters and Conditions
 ^      |      ^     | input: Ingredient (0 or many); output: Material (1) | Specification | Parameters and Conditions
-^      |      ^     | ^ | Realization | Parameters and Conditions
+^      |      ^     | ^ | Run | Parameters and Conditions
 `Measurement` | 3 point bend, combustion analysis | n/a | Template | Properties, Parameters, and Conditions
 ^      |      ^     | Material (1) |Specification | Parameters, and Conditions
-^      |      ^     | ^ | Realization | Properties, Parameters, and Conditions
+^      |      ^     | ^ | Run | Properties, Parameters, and Conditions
 `Ingredient` |      80wt%, 20lbs, solute     | Material (1) |Specification | n/a
-^      |      ^     | ^ | Realization | n/a
+^      |      ^     | ^ | Run | n/a
 
 *Table1:* Shows the relation of Objects to other Objects and Attributes possible in each state.
 
@@ -59,15 +59,15 @@ For example, a Process Object can have Parameters and Conditions as such: “sin
 Each Attribute has specified fields that are required or optional as defined in Table3 and Table6 below.
 
 ## How are States defined?
-There are 3 main states in which Data Objects exist: Templates, Specification, and Realization.
-Taurus distinguishes between the generalization of what might be done (Template), the intent to do something (Specification), and the realization of doing it (Realization).
+There are 3 main states in which Data Objects exist: Templates, Spec, and Run.
+Taurus distinguishes between the generalization of what might be done (Template), the intent to do something (Spec), and the actual result of doing it (Run).
 
 > As an example, one can have a Template for a Process Object defined as “sinter at {temperature} for {time} in kiln {id}”.
-This would be the Template used for a Specification of a kiln process used in the production of alumina.
+This would be the Template used for a Spec of a kiln process used in the production of alumina.
 The Specification of the Process object might be “sinter at 2400 K for 6 hours in kiln 14”.
-The Realization Process object would be what really happened when the process was conducted.
+The Process Run object would be what really happened when the process was conducted.
 For example, someone may have run the kiln and it ran at 2395 K.
-The Realization of the Process object would be “sinter at 2395 K for 5.75 hours in kiln 14”.
+The Run of the Process object would be “sinter at 2395 K for 5.75 hours in kiln 14”.
 
 All Data Objects (and all the Attributes that describe those Data Objects) in any State have specified fields that are required or optional, Table2 goes into further detail about the possible fields in all Data Objects and Attributes.
 
@@ -82,7 +82,7 @@ Field | Required/Optional | Quantity Possible
 ## Templates
 Templates are generalizations of Data Objects used to standardize data in Taurus.
 Templates are used at write time to validate data and at read time to associate groups of information together.
-Each Specification and Realization Object or Attribute (excluding Ingredient Objects and Metadata Attributes) requires a linked Template to support this read and write time association and validation respectively.
+Each Spec and Run Object or Attribute (excluding Ingredient Objects and Metadata Attributes) requires a linked Template to support this read and write time association and validation respectively.
 
 ### Attribute Templates
 An Attribute Template specifies the bounds that are acceptable for an Attribute.
@@ -132,21 +132,21 @@ Table5 below identifies all the possible Attributes that each Data Object can co
 
 Object Template | Property Template | Parameter Template | Condition Template
 ---------|----------|------------|------------
-`Material Template` | yes | no | no 
+`Material Template` | yes | no | no
 `Process Template` | no | yes | yes
 `Measurement Template` | yes | yes | yes
 
 *Table5*: Shows which Attributes can be linked to each Data Object in the Template state.
 
-## Specifications and Realizations
-Specifications (Specs) define the intent to do something, usually formalized in the format of an experiment request, the intention of an experiment, or the definition of a property.
-For example, the boiling point of water is defined as 100C, a specification.
+## Specs and Runs
+Specs define the intent to do something, usually formalized in the format of an experiment request, the intention of an experiment, or the definition of a property.
+For example, the normal boiling point of pure water is 99.61 C, a spec.
 
-Realizations (Runs) describe how a material, process, or measurement were actually performed, defined, or evaluated and the end results of that evaluation.
-For example, the water boiled at 101C, a realization.
+Runs describe how a material, process, or measurement were actually performed, defined, or evaluated and the end results of that evaluation.
+For example, a sample of water boiled at 101 C, a run.
 
-### Attribute in Specs and Runs 
-Each Attribute has specified fields that are required or optional for both Specification or Realization state.
+### Attribute in Specs and Runs
+Each Attribute has specified fields that are required or optional for both Spec or Run state.
 Table6 goes into further detail about the possible fields.
 Table6 represents the Attributes in diagram.
 
@@ -159,7 +159,7 @@ Field | Required/Optional | Quantity Possible
 `template` | Optional | one
 `file_links` | Optional | many
 
-*Table6*: Shows the fields available for Attributes in the Specifications and Realizations states.
+*Table6*: Shows the fields available for Attributes in the Spec and Run context.
 
 All attributes must specify the `origin` of their data as one of:
 * Specified: it is the intention to have this value
@@ -173,31 +173,31 @@ A `value` is a complex type that may contain both central (i.e. expected) and di
 It also includes units for real (i.e. continuous) values.
 
 
-### Data Object Specifications (Specs) and Realizations (Runs)
-Object Specifications require an associated Object Template that bounds the valid units and values of the Attributes on the Specification.
+### Data Object Specs and Runs
+Object Specs require an associated Object Template that bounds the valid units and values of the Attributes on the Spec.
 
-With the linking of Specs to Runs, Realizations inherit associated Templates through Specs.
+With the linking of Specs to Runs, Runs inherit associated Templates through Specs.
 For example, Process Runs associated with a Process Spec inherit the Template associated with the Spec, and their Attributes are thus also constrained by the Template.
 
-Many Specifications can reference the same Object Template.
-Each Specification can be associated with at most one Object Template (for now).
-Many Runs can reference the same Specification.
-Each Run must be associated with exactly one Specification.
+* Many Specs can reference the same Object Template.
+* Each Spec can be associated with at most one Object Template (for now).
+* Many Runs can reference the same Spec.
+* Each Run must be associated with exactly one Spec.
 
-As Object Specs define the intent to do something, they are more limited in possible fields than Realizations.
+As Object Specs define the intent to do something, they are more limited in possible fields than Runs.
 Table7 represents what additional fields are required or optional for Object Specs.
 
 Field | Required/Optional | Quantity Possible | Spec or Run
 ------|------------|---------------|-----
 `uids` | Optional | many | both
 `tags` | Optional | many | both
-`name` | Required | one | both 
+`name` | Required | one | both
 `notes` | Optional | one | both
 `file_links` | Optional | many | both
 `template` | Optional | one | Spec
 `spec` | Required | one | Run
 
-*Table7*: Shows the fields available for Material, Measurement, and Process Objects in the Specifications and Realizations states.
+*Table7*: Shows the fields available for Material, Measurement, and Process Objects in the Spec and Run contexts.
 
 Ingredient Objects are treated a little differently from the other Objects in taurus because they are mainly used to annotate a Material with information related to its usage in a Process.
 Table8 below identifies all the fields available in Ingredient Objects for both Specs and Runs.
@@ -217,5 +217,4 @@ Field | Required/Optional | Quantity Possible | In Spec or Run
 `absolute_quantity`| Optional | one | both
 `spec`| Required | one | Run
 
-*Table8*: Shows the fields available for Ingredient Objects in the Specifications and Realizations states.
-
+*Table8*: Shows the fields available for Ingredient Objects in the Spec and Run context.

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -24,11 +24,11 @@ which can be used to define controlled vocabularies in data.
 
 #### Validations define a controlled vocabulary
 
-Taurus captures validation in the form of 
+Taurus captures validation in the form of
 [Attribute Templates](../specification/attribute-templates) and
 [Object Templates](../specification/object-templates).
 These same objects serve to define a controlled vocabulary of domain concepts.
-The way that taurus indicates that a property is a "vapor pressure" vs an "ambient pressure" vs 
+The way that taurus indicates that a property is a "vapor pressure" vs an "ambient pressure" vs
 a "pressure applied on the horizontal face" is by defining templates for each of those concepts and assigning
 those templates to their corresponding properties.
 
@@ -83,10 +83,10 @@ The objects are linked in a chronological order from oldest to most recent.
 
 But if we try sometimes, we record what we'll need later.
 
-Taurus distinguishes between the intent to do something (a Specification) and the reality of what happened (a Realization).
+Taurus distinguishes between the intent to do something (a Spec) and the reality of what happened (a Run).
 Further, a single intent can be realized multiple times.
 This lets taurus capture both systematic and random errors.
-It also allows for the definition of intent to precede any realizations, supporting information hand-offs to experimental groups.
+It also allows for the definition of intent to precede generation of physical artifacts, supporting information hand-offs to experimental groups.
 
 
 #### Uncertainty quantification is opt-out rather than opt-in

--- a/docs/specification/attributes.md
+++ b/docs/specification/attributes.md
@@ -9,21 +9,21 @@ I measured the property to be a [Nominal Real Value](../value-types/#nominal-rea
 >  "The reading on the thermometer inside my oven as I bake cookies was 355 degrees, and I know that my thermometer is only accurate to +- 5 degrees, so I'll make that a [Uniform Real Value](../value-types/#uniform-real-value) with a `lower_bound` of 350 and an `upper_bound` of 360.
 
 **Parameters** are the non-environmental variables (typically specified and controlled) that may affect a process or measurement: e.g. Oven Dial Temperature Position for a kiln firing, or Magnification for a measurement taken with a SEM.
->  The "Bake Cookies" Process Specification has two parameters: a [Nominal Real Value](../value-types/#nominal-real-value) of 30 minutes for bake duration, and a [Nominal Real Value](../value-types/#nominal-real-value) of 350 degrees for oven temperature setting
+>  The "Bake Cookies" Process Spec has two parameters: a [Nominal Real Value](../value-types/#nominal-real-value) of 30 minutes for bake duration, and a [Nominal Real Value](../value-types/#nominal-real-value) of 350 degrees for oven temperature setting
 
 > I know my oven tends to run cold, so as I was baking I set my temperature setting to 360 degrees.
 I recorded this in the process run as a parameter with a [Nominal Real Value](../value-types/#nominal-real-value) of 360 Degrees.
 
 Typically, conditions are going to apply to _measured_ environmental variables in process runs and measurement runs.
-It may be appropriate to specify a Parameter attribute on a specification, and describe that attribute as a Condition on runs of that specification if the value is being measured as opposed to controlled during the run.
-It may also be appropriate to include _both_ a Paramter and a Condition on the run if the value is both controlled and measured.
-The use of Conditions in specifications should be limited in favor of parameters.
+It may be appropriate to specify a Parameter attribute on a Spec, and describe that attribute as a Condition on Runs of that Spec if the value is being measured as opposed to controlled during the Run.
+It may also be appropriate to include _both_ a Parameter and a Condition on the Run if the value is both controlled and measured.
+The use of Conditions in Specs should be limited in favor of parameters.
 
 Attributes are annotated with the `origin` of the data.  This field can have the following values:
 
 - `measured`: The Value of this Attribute was directly measured.
 - `predicted`: The Value of this Attribute came from a model, such as a complex simulation, a machine learning-derived computation or rule-of-thumb estimation
-- `specified`: The Value of this Attribute was dictated, such as the oven temperature in a [Process Specification](../objects#process-specification).  This value should only appear in Specifications.
+- `specified`: The Value of this Attribute was dictated, such as the oven temperature in a [Process Spec](../objects#process-spec).  This value should only appear in Specs.
 - `computed`: The Value of this Attribute was derived directly from measured values, such as computing the yield stress from a stress-strain curve or computing the density from known mass and volume measurements.
 - `unknown`: The origin of this Value is unknown.  This is the default value.
 
@@ -124,7 +124,7 @@ len(`notes`)  | <=    | 32,768 (32KB), UTF-8 Encoded
 
 ## Properties and Conditions
 
-In the [Material Spec](../objects#material-specification) object,
+In the [Material Spec](../objects#material-spec) object,
 one may need to specify a property along with the conditions under which the property occurs.
 For example:
 

--- a/docs/specification/object-templates.md
+++ b/docs/specification/object-templates.md
@@ -1,15 +1,15 @@
 # Object Templates
 
 Object Templates, like Attribute Templates, define a domain concept, e.g. convection baking in a standard residential oven, a cheesecake, or a taste test.
-Unlike Specifications, Object Templates define ranges validity.
+Unlike Specs, Object Templates define ranges validity.
 
-Object Templates contain collections of 
+Object Templates contain collections of
 [Attribute Templates](../attribute-templates/)
 that together constrain the values of an object's associated attributes to valid ranges.
 They also define a canonical name, a description, and can be tagged.
 
 The `parameters`, `properties`, and `conditions` fields in Object Templates are defined as sets of pair.
-Each pair contains at 
+Each pair contains at
 [Attribute Template](../attribute-templates/)
 and a Bounds that further constraints the bounds in the Attribute template.
 For example, the baking temperature might generally be defined to be between 100 degF and 1500 degF,
@@ -71,7 +71,7 @@ This is an example of a process template that has fully represented attribute te
                     "lower_bound" : 328,
                     "upper_bound" : 750
                 }
-            }, 
+            },
             {
                 "type" : "real_bounds",
                 "default_units" : "kelvin",
@@ -84,7 +84,7 @@ This is an example of a process template that has fully represented attribute te
                 "name" : "Baking Time",
                 "uids" : {"cookie_templates": "oven_time"},
                 "tags" : ["oven_settings::duration"],
-                
+
                 "description" : "A template for valid duration ranges for baking cookies.",
                 "bounds" : {
                     "default_units" : "seconds",
@@ -92,7 +92,7 @@ This is an example of a process template that has fully represented attribute te
                     "lower_bound" : 0,
                     "upper_bound" : 86400
                 }
-            }, 
+            },
             {
                 "type" : "real_bounds",
                 "default_units" : "seconds",
@@ -109,12 +109,12 @@ This is an example of a process template that has fully represented attribute te
 ## Material Template
 
 The Property Templates and Bounds contained in a material template are used to validate the properties in any
-[`PropertyAndCondition`](../attributes/#properties-and-conditions)s in the 
+[`PropertyAndCondition`](../attributes/#properties-and-conditions)s in the
 [Material Spec](../objects/#material-spec).
 They are not, however, used to validate the properties in any
 [Measurement Run](../objects/#measurement-run) objects attached to the
 [Material Run](../objects/#material-run).
-Rather, those properties are validated by the 
+Rather, those properties are validated by the
 [Measurement Template](../object-templates/#measurement-template).
 
 Field name    | Value type | Default | Description

--- a/docs/specification/objects.md
+++ b/docs/specification/objects.md
@@ -387,7 +387,7 @@ property names | must be unique | among property names
         "id" : "18d95397-4887-48f0-bdda-94a9a4c5ef45"
     },
     "name" : "Chocolate Chip Cookie Spec",
-    "notes" : "Material Specification for chocolate chip cookies",
+    "notes" : "Material Spec for chocolate chip cookies",
     "template" : {
         "type" : "link_by_uid",
         "scope" : "cookie_templates",
@@ -524,7 +524,7 @@ parameter names | must be unique | among parameter names
         "cookie_ids" : "choc_chip_hedonic_spec"
     },
     "name" : "Chocolate Chip Cookie Hedonic Index Measurement Spec",
-    "notes" : "Measurement Specification for measuring the hedonic index of chocolate chip cookies",
+    "notes" : "Measurement Specs for measuring the hedonic index of chocolate chip cookies",
     "template" : {
         "type" : "link_by_uid",
         "scope" : "cookie_templates",

--- a/docs/specification/objects.md
+++ b/docs/specification/objects.md
@@ -1,29 +1,29 @@
 # Objects
 
-There are two kinds of objects: Specifications ("Spec") and Realizations ("Run").
-Specifications represent the intent and expectation of the material, process, ingredient, or measurement,
-while Realizations capture what actually happened.
-This captures natural variations and forms an association between samples as multiple realizations of the same specification.
+There are two kinds of objects: Specs and Runs.
+Specs represent the intent and expectation of the material, process, ingredient, or measurement,
+while Runs capture what actually happened.
+This captures natural variations and forms an association between samples and design as multiple Runs of the same Spec.
 
-Specifications are specific.
+Specs are specific.
 In `MaterialSpec`, `ProcessSpec`, `IngredientSpec`, and `MeasurementSpec` objects, value should be given nominal values, e.g.:
-real-valued attributes on specifications should have [Nominal](../value-types/#nominal-real-values) values.
-This is in contrast to another common usage of the term "Specification" as a range of accepted values, i.e. "The material is in spec if the nitrogen impurity concentration is below 0.1%."
+real-valued attributes on Specs should have [Nominal Values](../value-types/#nominal-real-values).
+This is in contrast to another common usage of the term "Specification" (or tolerance) as a range of accepted values, e.g. "The material is in spec if the nitrogen impurity concentration is below 0.1%."
 In this data model, that notion of a "spec" that an object can "be in" is an [Object Template](../object-templates).
 
-Specifications can have an [Object Template](../object-templates/) associated, which bounds the valid units and values of the [attributes](../attributes) on the specification.
-Object runs associated with an object specification inherit the template associated with the spec, and their attributes are thus also constrained by the template.
+Specs can have an [Object Template](../object-templates/) associated, which bounds the valid units and values of the [Attributes](../attributes) on the Spec.
+Object Runs associated with an object Spec inherit the [Object Template](../object-templates/) associated with the Spec, and their [Attributes](../attributes) are thus also constrained by the [Object Template](../object-templates/).
 
 
-Many specifications can reference the same object template.
-Each specification can be associated with at most one object template.
-Many realizations can reference the same specification.
-Each run must be associated with exactly one specification.
+* Many Specs can reference the same Object Template.
+* Each Spec can be associated with at most one Object Template.
+* Many Runs can reference the same Spec.
+* Each Run must be associated with exactly one Spec.
 
 ---
-## Process Specification
+## Process Spec
 
-A specification for a process.
+An expectation of a process.
 Processes transform zero or more input materials into exactly one output material.
 
 
@@ -31,20 +31,20 @@ Field name | Value type | Default | Description
 -----------|------------|---------|-------------
 `uids`        | Map[String, String] | Empty | A collection of [Unique Identifiers](../unique-identifiers)
 `type`        | String     | Req. | "process_spec"
-`name`| String     | Req. | The name of the specification
-`notes`       | String     | None | Some free-form notes about the specification.
+`name`| String     | Req. | The name of the spec
+`notes`       | String     | None | Some free-form notes about the spec.
 `tags`        | Set[String]| Empty | [Tags](../tags)
 `file_links`  | Set\[[File Links](../file-links)] | Empty | Links to associated files, with resource paths into the files API
 `template`    | [Process Template](../object-templates/#process-template) | None | A template bounding the valid values for parameters and conditions on this process.
 `parameters`  | Set\[[Parameters](../attributes/#parameters)] | Empty | Specified parameters for the process spec
 `conditions`  | Set\[[Conditions](../attributes/#conditions)] | Empty | Specified conditions for the process spec
-`ingredients` | Set\[[Ingredient Spec](./#ingredient-specification)] | Empty | Ingredient Specifications
-`output_material` | [Material Spec](./#material-specification) | Req. | Output Material Specification
+`ingredients` | Set\[[Ingredient Spec](./#ingredient-spec)] | Empty | Ingredient Specs
+`output_material` | [Material Spec](./#material-spec) | Req. | Output Material Spec
 
 
 ##### Constraints
 
-All attributes sharing an [Attribute Template](../attribute-templates) with an attribute on the associated `template` will be constrained by the (potentially tighter) bounds set in the `template` Process Template.
+All [Attributes](../attributes) sharing an [Attribute Template](../attribute-templates) with an Attribute on the associated [Object Template](../object-templates/) will be constrained by the (potentially tighter) bounds set in the `template` Process Template.
 
 Field name | Relationship | Field Name
 -----------|:------------:|------------
@@ -65,7 +65,7 @@ condition names | must be unique | among condition names
         "baking::cookies"
     ],
     "name" : "Bake Cookies",
-    "notes" : "Process Specification for baking cookies in an oven",
+    "notes" : "Process Spec for baking cookies in an oven",
     "template" : {
         "type" : "link_by_uid",
         "scope" : "cookie_templates",
@@ -93,7 +93,7 @@ condition names | must be unique | among condition names
                 "nominal" : 450,
                 "units" : "kelvin"
             }
-        }, 
+        },
         {
             "type" : "parameter",
             "name" : "Baking Time",
@@ -134,7 +134,7 @@ condition names | must be unique | among condition names
 ---
 ## Process Run
 
-A realization of a process.
+A particular instance of a process.
 
 Field name | Value type | Default | Description
 -----------|------------|---------|------------
@@ -145,7 +145,7 @@ Field name | Value type | Default | Description
 `tags`        | Set[String]| Empty | [Tags](../tags)
 `file_links`  | Set\[[File Links](../file-links)] | Empty | Links to associated files, with resource paths into the files API
 `source`      | [Source](./#source) | None | provenance information for the process
-`spec`| [Process Spec](./#process-specification) | Req. | Spec for this process
+`spec`| [Process Spec](./#process-spec) | Req. | Spec for this process
 `parameters`  | Set\[[Parameters](../attributes/#parameters)] | Empty | Measured parameters for the process run
 `conditions`  | Set\[[Conditions](../attributes/#conditions)] | Empty | Measured conditions for the process run
 `ingredients` | Set\[[Ingredient Run](./#ingredient-run)] | Empty | Ingredient Runs
@@ -191,7 +191,7 @@ Same as `ProcessSpec`, but with the `template` inherited from the `spec`, i.e. `
                 "upper_bound" : 452.5,
                 "units" : "kelvin"
             }
-        }, 
+        },
         {
             "type" : "parameter",
             "name" : "Baking Time",
@@ -230,9 +230,9 @@ Same as `ProcessSpec`, but with the `template` inherited from the `spec`, i.e. `
 ```
 
 ---
-## Ingredient Specification
+## Ingredient Spec
 
-A specification for an ingredient, which annotates a material with information related to its usage in an individual process.
+The intent for an ingredient, which annotates a material with information related to its usage in an individual process.
 
 Field name | Value type | Default | Description
 -----------|------------|---------|------------
@@ -240,8 +240,8 @@ Field name | Value type | Default | Description
 `type`         | String     | Req. | "ingredient_spec"
 `name`| String     | Req. | The name of the ingredient, unique within the process that contains it
 `labels`       | Set[String] | Empty | Additional labels on the ingredient for describing the type or role of the ingredient
-`material`     | [Material Spec](./#material-specification) | Req. | Material that is this ingredient
-`notes`       | String     | Empty | Some free-form notes about the specification.
+`material`     | [Material Spec](./#material-spec) | Req. | Material that is this ingredient
+`notes`       | String     | Empty | Some free-form notes about the spec.
 `tags`        | Set[String]| Empty | [Tags](../tags)
 `file_links`  | Set\[[File Links](../file-links)] | Empty | Links to associated files, with resource paths into the files API
 `mass_fraction` | [Real Value](../value-types#real-values) | None | The mass fraction of the ingredient in the process
@@ -289,7 +289,7 @@ len(`name`) | <=    | 128, UTF-8 Encoded
 ---
 ## Ingredient Run
 
-A realization of an ingredient spec.
+A particular instance of an ingredient spec.
 
 Field name | Value type | Default | Description
 -----------|------------|---------|------------
@@ -298,14 +298,14 @@ Field name | Value type | Default | Description
 `name`| String     | Req. | The name of the ingredient, unique within the process that contains it
 `labels`       | Set[String] | Empty | Additional labels on the ingredient for describing the type or role of the ingredient
 `material`     | [Material Run](./#material-run) | Req. | Material that is this ingredient
-`notes`       | String     | None | Some free-form notes about the specification.
+`notes`       | String     | None | Some free-form notes about the run.
 `tags`        | Set[String]| Empty | [Tags](../tags)
 `file_links`  | Set\[[File Links](../file-links)] | Empty | Links to associated files, with resource paths into the files API
 `mass_fraction` | [Real Value](../value-types#real-values) | None | The mass fraction of the ingredient in the process
 `volume_fraction` | [Real Value](../value-types#real-values) | None | The volume fraction of the ingredient in the process
 `number_fraction` | [Real Value](../value-types#real-values) | None | The number fraction of the ingredient in the process
 `absolute_quantity` | [Real Value](../value-types#real-values) | None | The absolute quantity of the ingredient in the process
-`spec`| [Ingredient Spec](./#ingredient-specification) | Req. | The specification of which this is a realization
+`spec`| [Ingredient Spec](./#ingredient-spec) | Req. | The spec of which this is a run
 
 ##### Constraints
 
@@ -346,13 +346,13 @@ Field name | Relationship | Field Name
 
 
 ---
-## Material Specification
+## Material Spec
 
-A specification for a material.
+The expectation for a material.
 Materials have exactly one producing process.
-Material specifications may include specified properties,
+Material specs may include expected properties,
 but do so via the [PropertiesAndConditions](../attributes#properties-and-conditions) compound attribute.
-In this way, material specifications can associate a specified property value with the conditions under which it is specified.
+In this way, material specs can associate an expected property value with the conditions under which it is expected.
 For example, if a material is purchased and its Safety Data Sheet quotes a normal boiling point of 54 C,
 a property is known even though there is never an explicit measurement of that property by a person in the lab.  It could
 therefore be annotated with a Boiling Temperature of 54 C (property) at 1 atm (condition).
@@ -360,18 +360,18 @@ therefore be annotated with a Boiling Temperature of 54 C (property) at 1 atm (c
 Field name | Value type | Default | Description
 -----------|------------|---------|------------
 `uids`        | Map[String, String] | Empty | A collection of [Unique Identifiers](../unique-identifiers)
-`type`        | String     | Req. | "material\_spec"
-`name`| String     | Req. | The name of the specification
-`notes`       | String     | None | Some free-form notes about the specification.
+`type`        | String     | Req. | "material_spec"
+`name`| String     | Req. | The name of the spec
+`notes`       | String     | None | Some free-form notes about the spec.
 `tags`        | Set[String]| Empty | [Tags](../tags)
 `file_links`  | Set\[[File Links](../file-links)] | Empty | Links to associated files, with resource paths into the files API
 `template`    | [Material Template](../object-templates/#material-template) | None | A template bounding the valid values for properties of this material.
-`properties`  | Set\[[PropertiesAndConditions](../attributes/#properties-and-conditions)] | Empty | Specified properties for the material spec
-`process`     | [Process Spec](./#process-specification) | Req. | The process Spec that produces this material
+`properties`  | Set\[[PropertiesAndConditions](../attributes/#properties-and-conditions)] | Empty | Expected properties for the material spec
+`process`     | [Process Spec](./#process-spec) | Req. | The Process Spec that produces this material
 
 ##### Constraints
 
-All attributes sharing an [Attribute Template](../attribute-templates) with an attribute on the associated `template` will be constrained by the (potentially tighter) bounds set in the `template`.
+All Attributes sharing an [Attribute Template](../attribute-templates) with an Attribute on the associated Object Template will be constrained by the (potentially tighter) bounds set in the `template` Material Template.
 
 Field name | Relationship | Field Name
 -----------|:------------:|------------
@@ -436,7 +436,7 @@ property names | must be unique | among property names
 ---
 ## Material Run
 
-A realization of a material, e.g. a sample, ingot, or wafer.
+A particular instance of a material, e.g. a sample, ingot, or wafer.
 
 Field name | Value type | Default | Description
 -----------|------------|---------|------------
@@ -446,10 +446,10 @@ Field name | Value type | Default | Description
 `notes`       | String     | None | Some free-form notes about the material run
 `tags`        | Set[String]| Empty | [Tags](../tags)
 `file_links`  | Set\[[File Links](../file-links)] | Empty | Links to associated files, with resource paths into the files API
-`spec`        | [Material Spec](./#material-specification) | Req. | The material specification of which this is a realization
-`process`     | [Process Run](./#process-run) | Req. | The process run that produced this material
-`measurements`  | Set\[[Measurement Run](./#measurement-run)] | Empty | characterizations of this material run
-`sample_type`   | `experimental`, `production`, or `virtual`, `unknown` | `unknown` | Context of how this material was realized
+`spec`        | [Material Spec](./#material-spec) | Req. | The material spec of which this is a run
+`process`     | [Process Run](./#process-run) | Req. | The Process Run that produced this material
+`measurements`  | Set\[[Measurement Run](./#measurement-run)] | Empty | characterizations of this Material Run
+`sample_type`   | `experimental`, `production`, or `virtual`, `unknown` | `unknown` | Context of how this material was made to be
 
 
 ##### Constraints
@@ -489,16 +489,16 @@ Same as Material Spec, but with the `template` inherited from the `spec`, i.e. `
 
 
 ---
-## Measurement Specification
+## Measurement Spec
 
-A specification for a measurement, indicating the parameters of and conditions under which to perform the measurement.
+An expectation for a measurement, indicating the parameters of and conditions under which to perform the measurement.
 
 Field name | Value type | Default | Description
 -----------|------------|---------|------------
 `uids`        | Map[String, String] | Empty | A collection of [Unique Identifiers](../unique-identifiers)
 `type`        | String     | Req. | "measurement_spec"
-`name`| String     | Req. | The name of the specification
-`notes`       | String     | None | Some free-form notes about the specification.
+`name`| String     | Req. | The name of the spec
+`notes`       | String     | None | Some free-form notes about the spec.
 `tags`        | Set[String]| Empty | [Tags](../tags)
 `file_links`  | Set\[[File Links](../file-links)] | Empty | Links to associated files, with resource paths into the files API
 `template`    | [Measurement Template](../object-templates/#measurement-template) | None | A template bounding the valid values for parameter and conditions of the measurement.
@@ -507,7 +507,7 @@ Field name | Value type | Default | Description
 
 ##### Constraints
 
-All attributes sharing an [Attribute Template](../attribute-templates) with an attribute on the associated `template` will be constrained by the (potentially tighter) bounds set in the `template`.
+All attributes sharing an [Attribute Template](../attribute-templates) with an attribute on the associated Object Template will be constrained by the (potentially tighter) bounds set in the `template`.
 
 Field name      | Relationship   | Field Name
 ----------------|:--------------:|------------
@@ -571,7 +571,7 @@ parameter names | must be unique | among parameter names
 ---
 ## Measurement Run
 
-A realization of a measurement.
+A particular instance of a measurement.
 
 Field name | Value type | Default | Description
 -----------|------------|---------|------------
@@ -582,7 +582,7 @@ Field name | Value type | Default | Description
 `tags`        | Set[String]| Empty | [Tags](../tags)
 `file_links`  | Set\[[File Links](../file-links)] | Empty | Links to associated files, with resource paths into the files API
 `source`      | [Source](./#source) | None | provenance information for the measurement
-`spec`        | [Measurement Spec](./#measurement-specification) | Req. | The measurement specification of which this is a realization
+`spec`        | [Measurement Spec](./#measurement-spec) | Req. | The measurement spec of which this is a run
 `material`    | [Material Run](./#material-run) | Req. | The material run being measured
 `parameters`  | Set\[[Parameters](../attributes/#parameters)] | Empty | Measured parameters for the measurement
 `conditions`  | Set\[[Conditions](../attributes/#conditions)] | Empty | Measured conditions for the measurement
@@ -678,7 +678,7 @@ parameter names | must be unique | among parameter names
 ## Source
 
 Provenance is the documented history of an Object.
-This includes information such as who performed a measurement, the literature source for a process specification, or the purveyor and catalog number for a purchased material.
+This includes information such as who performed a measurement, the literature source describing the design of a process, or the purveyor and catalog number for a purchased material.
 This type of information tends to have limited value for modeling and other analysis but is essential for verification and auditing.
 
 At present the only type of source supported is who performed a task and when they did so.
@@ -699,4 +699,3 @@ Field name    | Value type | Default | Description
     "performed_date": "2015-03-14T15:09:27"
 }
 ```
-


### PR DESCRIPTION
Modified documentation to remove references to Specifications and Realizations.

Minor additional issues, such as grammar and link formatting, corrected in the process.