### PR TITLE
Clarify that attribute names/templates are unique within objects

### DIFF
--- a/docs/specification/object-templates.md
+++ b/docs/specification/object-templates.md
@@ -15,6 +15,7 @@ and a Bounds that further constraints the bounds in the Attribute template.
 For example, the baking temperature might generally be defined to be between 100 degF and 1500 degF,
 but a Process Template describing a specific oven model may constrain the baking temperature to be between 150 degF and 550 degF.
 The Bounds must fall within the Attribute Template's Bounds, and should be set to those Bounds if no further constraint is desired.
+Each Attribute Template can only be included in each Object Template once.
 
 ---
 ## Process Template
@@ -41,6 +42,8 @@ Field name | Relationship | Field Name
 len(`name`) | <=    | 128, UTF-8 Encoded
 len(`description`)  | <=    | 32,768 (32KB), UTF-8 Encoded
 Bounds | contained in | Attribute template bounds
+parameters templates | are unique within | parameters
+condition templates | are unique within | conditions
 
 ##### Example
 
@@ -133,6 +136,7 @@ Field name | Relationship | Field Name
 -----------|:------------:|------------
 len(`name`) | <=    | 128, UTF-8 Encoded
 len(`description`)  | <=    | 32,768 (32KB), UTF-8 Encoded
+property templates | are unique within | properties
 
 ##### Examples
 
@@ -212,6 +216,9 @@ Field name | Relationship | Field Name
 -----------|:------------:|------------
 len(`name`) | <=    | 128, UTF-8 Encoded
 len(`description`)  | <=    | 32,768 (32KB), UTF-8 Encoded
+property templates | are unique within | properties
+parameters templates | are unique within | parameters
+condition templates | are unique within | conditions
 
 ##### Examples
 

--- a/docs/specification/object-templates.md
+++ b/docs/specification/object-templates.md
@@ -15,7 +15,7 @@ and a Bounds that further constraints the bounds in the Attribute template.
 For example, the baking temperature might generally be defined to be between 100 degF and 1500 degF,
 but a Process Template describing a specific oven model may constrain the baking temperature to be between 150 degF and 550 degF.
 The Bounds must fall within the Attribute Template's Bounds, and should be set to those Bounds if no further constraint is desired.
-Each Attribute Template can only be included in each Object Template once.
+Each Attribute Template can only be included in a given Object Template's Attribute list once (e.g., once in `properties` and once in `conditions`).
 
 ---
 ## Process Template

--- a/docs/specification/objects.md
+++ b/docs/specification/objects.md
@@ -21,12 +21,13 @@ Object Runs associated with an object Spec inherit the [Object Template](../obje
 * Each Run must be associated with exactly one Spec.
 
 
-The mechanism for [Attribute](../attributes) validation is through [Attribute Templates](../attribute-templates).  
-If the Attribute's template is set, the Attribute's [Value](../value-types) is validated against the constraints defined in that template.  
-If the [Object Template](../object-templates/) has further restricted the bounds of the Attribute Template, then those tighter constraints are enforced.  
+The mechanism for [Attribute](../attributes) validation is through [Attribute Templates](../attribute-templates).
+If the Attribute's template is set, the Attribute's [Value](../value-types) is validated against the constraints defined in that template.
+If the [Object Template](../object-templates/) has further restricted the bounds of the Attribute Template, then those tighter constraints are enforced.
 The Properties, Parameters and Conditions of Object Templates and of Objects are matched when they point at the same Attribute Template.
 
 An [Object](../objects) can have [Attributes](../attributes) that are not defined in its [Object Template](../object-templates), and an Object Template can have Attributes that are not defined in associated Objects.
+However, an Object cannot have two attributes of the same type (Property, Parameter, or Condition) with the same name or the same attribute template.
 
 ---
 ## Process Spec
@@ -60,6 +61,9 @@ len(`name`) | <=    | 128, UTF-8 Encoded
 len(`description`)  | <=    | 32,768 (32KB), UTF-8 Encoded
 parameter names | must be unique | among parameter names
 condition names | must be unique | among condition names
+parameter templates | must be unique | among the templates of parameters
+condition templates | must be unique | among the templates of conditions
+
 
 ##### Example
 
@@ -267,6 +271,7 @@ len(`name`) | <=    | 128, UTF-8 Encoded
 `mass_fraction` | <= | 1
 `volume_fraction` | <= | 1
 `number_fraction` | <= | 1
+name | must be unique | among the ingredients of process 
 
 ##### Example
 
@@ -329,6 +334,7 @@ Field name | Relationship | Field Name
 `mass_fraction` | <= | 1
 `volume_fraction` | <= | 1
 `number_fraction` | <= | 1
+name | must be unique | among the ingredients of process 
 
 An Ingredient Run and its spec must be paired with a linked Material Run/Spec pair and with a linked Process Run/Spec pair.
 The spec's process and the process's spec must point to the same Process Spec.
@@ -550,6 +556,10 @@ Field name      | Relationship   | Field Name
 property names  | must be unique | among property names
 condition names | must be unique | among condition names
 parameter names | must be unique | among parameter names
+property templates | must be unique | among the templates of properties
+parameter templates | must be unique | among the templates of parameters
+condition templates | must be unique | among the templates of conditions
+
 
 ##### Example
 
@@ -632,6 +642,9 @@ Field name      | Relationship   | Field Name
 property names  | must be unique | among property names
 condition names | must be unique | among condition names
 parameter names | must be unique | among parameter names
+property templates | must be unique | among the templates of properties
+parameter templates | must be unique | among the templates of parameters
+condition templates | must be unique | among the templates of conditions
 
 ##### Example
 


### PR DESCRIPTION
SSIA.  This is consistent with what is understood/communicated in other places, but wasn't clearly expressed in this documentation.