### PR TITLE
Update Ingredient constraints on names and labels

### DIFF
--- a/docs/high-level-overview.md
+++ b/docs/high-level-overview.md
@@ -201,6 +201,7 @@ Field | Required/Optional | Quantity Possible | Spec or Run
 *Table7*: Shows the fields available for Material, Measurement, and Process Objects in the Spec and Run contexts.
 
 Ingredient Objects are treated a little differently from the other Objects in taurus because they are mainly used to annotate a Material with information related to its usage in a Process.
+Note that constraints on `name` and `labels` follow from the `allowed_names` and `allowed_labels` fields of the Process Template.
 Table8 below identifies all the fields available in Ingredient Objects for both Specs and Runs.
 
 Field | Required/Optional | Quantity Possible | In Spec or Run
@@ -209,8 +210,8 @@ Field | Required/Optional | Quantity Possible | In Spec or Run
 `tags` | Optional | many | both
 `notes` | Optional | one | both
 `file_links` | Optional | many | both
-`name` | Optional | one | both
-`labels` | Optional | many | both
+`name` | Optional | one | Spec
+`labels` | Optional | many | Spec
 `material` | Required | one | both (with material object from respective state)
 `mass_fraction` | Optional | one | both
 `volume_fraction`| Optional | one | both

--- a/docs/specification/objects.md
+++ b/docs/specification/objects.md
@@ -6,7 +6,7 @@ while Runs capture what actually happened.
 This captures natural variations and forms an association between samples and design as multiple Runs of the same Spec.
 
 Specs are specific.
-In `MaterialSpec`, `ProcessSpec`, `IngredientSpec`, and `MeasurementSpec` objects, value should be given nominal values, e.g.:
+In `MaterialSpec`, `ProcessSpec`, `IngredientSpec`, and `MeasurementSpec` objects, `value` should be given nominal values, e.g.:
 real-valued attributes on Specs should have [Nominal Values](../value-types/#nominal-real-values).
 This is in contrast to another common usage of the term "Specification" (or tolerance) as a range of accepted values, e.g. "The material is in spec if the nitrogen impurity concentration is below 0.1%."
 In this data model, that notion of a "spec" that an object can "be in" is an [Object Template](../object-templates).
@@ -245,6 +245,8 @@ Same as `ProcessSpec`, but with the `template` inherited from the `spec`, i.e. `
 ## Ingredient Spec
 
 The intent for an ingredient, which annotates a material with information related to its usage in an individual process.
+Note that the `name` and `labels` for an Ingredient Spec are shared with all associated Ingredient Runs.
+These might be better thought of as the name of the role of a material in the process (e.g., binder) and not of the material itself (e.g., portland cement).
 
 Field name | Value type | Default | Description
 -----------|------------|---------|------------
@@ -271,7 +273,7 @@ len(`name`) | <=    | 128, UTF-8 Encoded
 `mass_fraction` | <= | 1
 `volume_fraction` | <= | 1
 `number_fraction` | <= | 1
-name | must be unique | among the ingredients of process 
+name | must be unique | among the ingredients of process
 
 ##### Example
 
@@ -314,8 +316,6 @@ Field name | Value type | Default | Description
 -----------|------------|---------|------------
 `uids`         | Map[String, String] | Empty | A collection of [Unique Identifiers](../unique-identifiers)
 `type`         | String     | Req. | "ingredient_run"
-`name`| String     | Req. | The name of the ingredient, unique within the process that contains it
-`labels`       | Set[String] | Empty | Additional labels on the ingredient for describing the type or role of the ingredient
 `material`     | [Material Run](./#material-run) | Req. | Material that is this ingredient
 `process`      | [Process Run](./#process-run) | Req. | Process that the ingredient is used in
 `notes`       | String     | None | Some free-form notes about the run.
@@ -334,7 +334,6 @@ Field name | Relationship | Field Name
 `mass_fraction` | <= | 1
 `volume_fraction` | <= | 1
 `number_fraction` | <= | 1
-name | must be unique | among the ingredients of process 
 
 An Ingredient Run and its spec must be paired with a linked Material Run/Spec pair and with a linked Process Run/Spec pair.
 The spec's process and the process's spec must point to the same Process Spec.
@@ -373,9 +372,7 @@ material.spec | = | spec.material
         "type" : "normal_real",
         "mean" : 0.347,
         "std" : 0.002
-    },
-    "name" : "cookie",
-    "labels" : ["faces"]
+    }
 }
 ```
 

--- a/docs/specification/objects.md
+++ b/docs/specification/objects.md
@@ -279,6 +279,8 @@ len(`name`) | <=    | 128, UTF-8 Encoded
 `volume_fraction.units` | == | `dimensionless`
 `number_fraction.units` | == | `dimensionless`
 `name` | must be unique | among the ingredients of process
+`name` | must be contained | `process.template.allowed_names`, if `allowed_names` defined
+`labels` | must be contained | `process.template.allowed_labels`, if `allowed_labels` defined
 
 ##### Example
 
@@ -344,7 +346,6 @@ Field name | Relationship | Field Name
 `mass_fraction.units` | == | `dimensionless`
 `volume_fraction.units` | == | `dimensionless`
 `number_fraction.units` | == | `dimensionless`
-`name` | must be unique | among the ingredients of process
 
 An Ingredient Run and its spec must be paired with a linked Material Run/Spec pair and with a linked Process Run/Spec pair.
 The spec's process and the process's spec must point to the same Process Spec.


### PR DESCRIPTION
Updated Objects and High Level Overview to reflect new constraints on Ingredient names and labels.

As per:

https://citrine.atlassian.net/browse/PLA-1678
https://citrine.atlassian.net/wiki/spaces/PLA/pages/104890529/Names+and+Labels+for+Ingredients