### PR TITLE
typo and broken link in README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,27 +1,17 @@
 # Taurus Data Model Documentation
 
-This the next major data model developed by Citrine, codename `taurus`.
+This is the next major data model developed by Citrine, codename `taurus`.
 
-The format links together materials, the processes that produced them,
-and the measurements that characterize them.
-This facilitates the backwards traversal from a measurement to the material on which it was performed
-to the process by which it was produced to the materials which were used in that process and so on and so forth.
-This generalizes and matures the PIF's `preparation` and `subSystems` objects.
+The model links together materials, the processes that produced them,
+and the measurements that characterize them. This facilitates the backwards traversal from a measurement to the material on which it was performed to the process by which it was produced to the materials which were used in that process. This generalizes and matures `preparation` and `subSystems` objects within the Physical Information File (PIF).
 
-Additionally, this format makes a first-class distinction between *intent* and *realization*, 
-captured by `Spec` and `Run` objects, respectively.
-A single intent `Spec` can be realized into multiple `Run` objects.
-This generalized and matures the `ideal` concept from the PIF's `Composition` and `Quantity` objects.
+Additionally, the model makes a first-class distinction between *intent* and *realization*, captured by `Spec` and `Run` objects, respectively. A single intent `Spec` can be realized into multiple `Run` objects. This generalizes and matures the `ideal` concept from the PIF's `Composition` and `Quantity` objects.
 
-This format contains a new type of object: the [`Measurement`](./objects/#measurement-run).
-Measurement's capture data and meta-data about a discrete measurement activity, including the parameters and conditions
-associated with a set of measured properties.
-This many-to-many relationship between properties, conditions, and parameters resolves a fundamental ambiguity present
-in the PIF: which properties were measured at the same time under the same conditions?
+The model contains a new type of object: the [`Measurement Run`](./specification/objects/#measurement-run). Measurements capture discrete measurement activity, including the parameters and conditions associated with a set of measured properties. This many-to-many relationship between properties, conditions, and parameters resolves a fundamental ambiguity present in the PIF; which properties were measured at the same time under the same conditions?
 
 ## Specification of the NextGen Data format 
 
-The format is described in these subsections:
+The format is described in the following subsections:
 
 * [Value Types](./specification/value-types)
 * [Attributes](./specification/attributes)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,12 +2,16 @@
 
 This is the next major data model developed by Citrine, codename `taurus`.
 
-The model links together materials, the processes that produced them,
-and the measurements that characterize them. This facilitates the backwards traversal from a measurement to the material on which it was performed to the process by which it was produced to the materials which were used in that process. This generalizes and matures `preparation` and `subSystems` objects within the Physical Information File (PIF).
+The model links together materials, the processes that produced them, and the measurements that characterize them.
+This facilitates the backwards traversal from a measurement to the material on which it was performed to the process by which it was produced to the materials which were used in that process. 
+It generalizes and matures `preparation` and `subSystems` objects within the Physical Information File (PIF).
 
-Additionally, the model makes a first-class distinction between *intent* and *realization*, captured by `Spec` and `Run` objects, respectively. A single intent `Spec` can be realized into multiple `Run` objects. This generalizes and matures the `ideal` concept from the PIF's `Composition` and `Quantity` objects.
+Additionally, the model makes a first-class distinction between *intent* and *realization*, captured by `Spec` and `Run` objects, respectively. 
+A single intent `Spec` can be realized into multiple `Run` objects. This generalizes and matures the `ideal` concept from the PIF's `Composition` and `Quantity` objects.
 
-The model contains a new type of object: the [`Measurement Run`](./specification/objects/#measurement-run). Measurements capture discrete measurement activity, including the parameters and conditions associated with a set of measured properties. This many-to-many relationship between properties, conditions, and parameters resolves a fundamental ambiguity present in the PIF; which properties were measured at the same time under the same conditions?
+The model contains a new type of object: the [`Measurement Run`](./specification/objects/#measurement-run). 
+Measurements capture discrete measurement activity, including the parameters and conditions associated with a set of measured properties. 
+This many-to-many relationship between properties, conditions, and parameters resolves a fundamental ambiguity present in the PIF; which properties were measured at the same time under the same conditions?
 
 ## Specification of the NextGen Data format 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,8 @@ This facilitates the backwards traversal from a measurement to the material on w
 It generalizes and matures `preparation` and `subSystems` objects within the Physical Information File (PIF).
 
 Additionally, the model makes a first-class distinction between *intent* and *realization*, captured by `Spec` and `Run` objects, respectively. 
-A single intent `Spec` can be realized into multiple `Run` objects. This generalizes and matures the `ideal` concept from the PIF's `Composition` and `Quantity` objects.
+A single intent `Spec` can be realized into multiple `Run` objects.
+This generalizes and matures the `ideal` concept from the PIF's `Composition` and `Quantity` objects.
 
 The model contains a new type of object: the [`Measurement Run`](./specification/objects/#measurement-run). 
 Measurements capture discrete measurement activity, including the parameters and conditions associated with a set of measured properties. 
@@ -29,4 +30,3 @@ The format is described in the following subsections:
 ## Getting help
 
 Check out our [FAQ](./faq.md)!
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This is the next major data model developed by Citrine, codename `taurus`.
 
 The model links together materials, the processes that produced them, and the measurements that characterize them.
 This facilitates the backwards traversal from a measurement to the material on which it was performed to the process by which it was produced to the materials which were used in that process. 
-It generalizes and matures `preparation` and `subSystems` objects within the Physical Information File (PIF).
+It generalizes and matures `preparation` and `subSystems` objects within the PIF ([Physical Information File](https://citrineinformatics.github.io/pif-documentation/)).
 
 Additionally, the model makes a first-class distinction between *intent* and *realization*, captured by `Spec` and `Run` objects, respectively. 
 A single intent `Spec` can be realized into multiple `Run` objects.


### PR DESCRIPTION
As I go through the documentation I found a couple of typo's, a broken link, etc. Wondering it you would like me to capture this in a PR as I go through it?

**Highlights**
* a couple of typos
* broken link to the `Measurement Run`
* some very subjective cosmetic changes that hopefully don't change the semantics

