### PR TITLE
s/nominal/category/

### DIFF
--- a/docs/specification/value-types.md
+++ b/docs/specification/value-types.md
@@ -226,7 +226,7 @@ Nominal value, which does not specify an uncertainty but is not to be assumed to
 Field name      | Value type | Description
 ----------------|------------|------------
 `type`          | String     | "nominal\_categorical"
-`nominal `      | String     | The category of the value
+`category `     | String     | The category of the value
 
 ##### Constraints
 
@@ -237,7 +237,7 @@ None
 ```json
 {
     "type" : "nominal_categorical",
-    "nominal" : "red"
+    "category" : "red"
 }
 ```
 

--- a/docs/specification/value-types.md
+++ b/docs/specification/value-types.md
@@ -226,7 +226,7 @@ Nominal value, which does not specify an uncertainty but is not to be assumed to
 Field name      | Value type | Description
 ----------------|------------|------------
 `type`          | String     | "nominal\_categorical"
-`category `     | String     | The category of the value
+`category`      | String     | The category of the value
 
 ##### Constraints
 


### PR DESCRIPTION
s/nominal/category/ for nominal categoricals, to comply with deployed clients and code

https://citrine.atlassian.net/browse/PLA-2280

Taurus:
https://github.com/CitrineInformatics/taurus/blob/develop/taurus/entity/value/nominal_categorical.py#L23-L33

Datasvc:
https://github.com/CitrineInformatics/platform-backend/blob/develop/code/faraday/model/src/main/scala/io/citrine/faraday/api/model/values/CategoricalValue.scala#L34