### PR TITLE
PLA-2252: typo and formatting

### DIFF
--- a/docs/specification/value-types.md
+++ b/docs/specification/value-types.md
@@ -3,13 +3,13 @@
 Value is a generic term for the information contained in an [attribute](../attributes).
 A Value may be one of the following Value Types:
 
-Value Type|Variant|Description
----------|-------|-----------
-**RealValue**|`NominalReal`<br>`NormalReal`<br>`UniformReal`|A double value and a unit (e.g., 32F, 45 meters, 14 kg).<br><br>Each variation provides a different mechanism for defining uncertainty.
-**IntegerValue**|`NominalInteger`<br>`UniformInteger`|A whole integer value.
-**Categorical**|`NominalCategorical`<br>`DiscreteCategorical`|Categorical values are distributions over the valid category names representing the probability of each category.  For DiscreteCategorical, the values must sum to 1.0.
-**Composition**|`NominalComposition`<br>`EmpiricalFormula`|A value containing the composition of the material as a a map from the names of the components to their numerical quantities. The quantities are not required to be expressed on a unit or fractional basis.
-**Molecular**|`Smiles`<br>`Inchi`|Molecular structure using popular encoding schemes
+| Value Type       | Variant                                        | Description                                                                                                                                                                                                |
+|------------------|------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **RealValue**    | `NominalReal`<br>`NormalReal`<br>`UniformReal` | A double value and a unit (e.g., 32F, 45 meters, 14 kg).<br><br>Each variation provides a different mechanism for defining uncertainty.                                                                    |
+| **IntegerValue** | `NominalInteger`<br>`UniformInteger`           | A whole integer value.                                                                                                                                                                                     |
+| **Categorical**  | `NominalCategorical`<br>`DiscreteCategorical`  | Categorical values are distributions over the valid category names representing the probability of each category.  For DiscreteCategorical, the values must sum to 1.0.                                    |
+| **Composition**  | `NominalComposition`<br>`EmpiricalFormula`     | A value containing the composition of the material as a map from the names of the components to their numerical quantities. The quantities are not required to be expressed on a unit or fractional basis. |
+| **Molecular**    | `Smiles`<br>`Inchi`                            | Molecular structure using popular encoding schemes                                                                                                                                                         |
 
 <!-- We might add these back later, but they are currently unused
 **Boolean**	 |       |A true/false value (e.g., active, deleted)
@@ -41,18 +41,18 @@ From a computational perspective, this means Normal Real Values are actually
 truncated Gaussians, though this is only significant for a distribution
 near the boundary.
 
-Field name  | Value type    | Description
-------------|---------------|------------
-`type`      | String        | "normal\_real"
-`mean`      | Number        | Mean of the distribution
-`std`       | Number        | Standard deviation of the normal distribution
-`units`     | String        | A String describing the units
+| Field name | Value type | Description                                   |
+|------------|------------|-----------------------------------------------|
+| `type`     | String     | "normal\_real"                                |
+| `mean`     | Number     | Mean of the distribution                      |
+| `std`      | Number     | Standard deviation of the normal distribution |
+| `units`    | String     | A String describing the units                 |
 
 ##### Constraints
 
-Field name    | Relationship | Field Name
---------------|:------------:|------------
-`std`         | >=           | 0
+| Field name | Relationship | Field Name |
+|------------|:------------:|------------|
+| `std`      |      >=      | 0          |
 
 ##### Example
 
@@ -72,17 +72,17 @@ A Uniform continuous distribution value, with inclusive lower and upper bounds.
 These are especially useful for expressing uncertainty when the number of digits is truncated.
 In order to be valid, the entirety of the distribution must fall within the bounds.
 
-Field name | Value type | Description
------------|------------|------------
-`type`      | String    | "uniform\_real"
-`lower_bound` | Number | Lower bound of the distribution
-`upper_bound` | Number | Upper bound of the distribution
-`units`     | String     | A String describing the units
+| Field name    | Value type | Description                     |
+|---------------|------------|---------------------------------|
+| `type`        | String     | "uniform\_real"                 |
+| `lower_bound` | Number     | Lower bound of the distribution |
+| `upper_bound` | Number     | Upper bound of the distribution |
+| `units`       | String     | A String describing the units   |
 ##### Constraints
 
-Field name    | Relationship | Field Name
---------------|:------------:|------------
-`lower_bound` | <=           | `upper_bound`
+| Field name    | Relationship | Field Name    |
+|---------------|:------------:|---------------|
+| `lower_bound` |      <=      | `upper_bound` |
 
 ##### Example
 
@@ -101,11 +101,11 @@ A value field read off a digital display with 3 decimal points.
 
 Nominal value, which does not specify an uncertainty but is not to be assumed to be exact.
 
-Field name | Value type | Description
------------|------------|------------
-`type`     | String     | "nominal\_real"
-`nominal`  | Number     | A nominal value - not assumed to be exact
-`units`    | String     | A String describing the units
+| Field name | Value type | Description                               |
+|------------|------------|-------------------------------------------|
+| `type`     | String     | "nominal\_real"                           |
+| `nominal`  | Number     | A nominal value - not assumed to be exact |
+| `units`    | String     | A String describing the units             |
 
 ##### Constraints
 
@@ -134,17 +134,17 @@ A uniform integer distribution value, with inclusive lower and upper bounds.
 These are especially useful for expressing uncertainty when the number of digits is truncated.
 In order to be valid, the entirety of the distribution must fall within the bounds.
 
-Field name | Value type | Description
------------|------------|------------
-`type`      | String    | "uniform\_integer"
-`lower_bound` | Integer | Lower bound of the distribution
-`upper_bound` | Integer | Upper bound of the distribution
+| Field name    | Value type | Description                     |
+|---------------|------------|---------------------------------|
+| `type`        | String     | "uniform\_integer"              |
+| `lower_bound` | Integer    | Lower bound of the distribution |
+| `upper_bound` | Integer    | Upper bound of the distribution |
 
 ##### Constraints
 
-Field name    | Relationship | Field Name
---------------|:------------:|------------
-`lower_bound` | <=           | `upper_bound`
+| Field name    | Relationship | Field Name    |
+|---------------|:------------:|---------------|
+| `lower_bound` |      <=      | `upper_bound` |
 
 ##### Example
 
@@ -161,10 +161,10 @@ A value field read off a digital display with 3 decimal points.
 
 Nominal value, which does not specify an uncertainty but is not to be assumed to be exact.
 
-Field name | Value type | Description
------------|------------|------------
-`type`     | String     | "nominal\_integer"
-`nominal`  | Integer    | A nominal value - not assumed to be exact
+| Field name | Value type | Description                               |
+|------------|------------|-------------------------------------------|
+| `type`     | String     | "nominal\_integer"                        |
+| `nominal`  | Integer    | A nominal value - not assumed to be exact |
 
 ##### Constraints
 
@@ -195,17 +195,17 @@ a discrete (i.e. enumerated) distribution and a nominal (i.e. specified) value.
 
 Distribution of categories stored as a map from the string label to the probability
 
-Field name      | Value type | Description
-----------------|------------|------------
-`type`          | String     | "discrete\_categorical"
-`probabilities` | Map[String, Number] | A map from string category names to their probability.
+| Field name      | Value type          | Description                                            |
+|-----------------|---------------------|--------------------------------------------------------|
+| `type`          | String              | "discrete\_categorical"                                |
+| `probabilities` | Map[String, Number] | A map from string category names to their probability. |
 
 ##### Constraints
 
-Field name                             | Relationship | Field Name
----------------------------------------|:------------:|------------
-abs(sum(probabilities.values()) - 1.0) | <            | 1.0e-9
-each probability value                 | >=           | 0
+| Field name                             | Relationship | Field Name |
+|----------------------------------------|:------------:|------------|
+| abs(sum(probabilities.values()) - 1.0) |      <       | 1.0e-9     |
+| each probability value                 |      >=      | 0          |
 
 ##### Example
 
@@ -223,10 +223,10 @@ each probability value                 | >=           | 0
 
 Nominal value, which does not specify an uncertainty but is not to be assumed to be exact.
 
-Field name      | Value type | Description
-----------------|------------|------------
-`type`          | String     | "nominal\_categorical"
-`category`      | String     | The category of the value
+| Field name | Value type | Description               |
+|------------|------------|---------------------------|
+| `type`     | String     | "nominal\_categorical"    |
+| `category` | String     | The category of the value |
 
 ##### Constraints
 
@@ -253,16 +253,16 @@ For example "one part flour two parts sugar" is acceptable.
 A composition represented as a map from the component name to the quantity.
 The quantities do not express an uncertainty, but also do not imply that there is absolute certainty in their values.
 
-Field name      | Value type | Description
-----------------|------------|------------
-`type`          | String     | "nominal\_composition"
-`quantities`    | Map[String, Number]     | Map[String, Number]
+| Field name   | Value type          | Description            |
+|--------------|---------------------|------------------------|
+| `type`       | String              | "nominal\_composition" |
+| `quantities` | Map[String, Number] | Map[String, Number]    |
 
 ##### Constraints
 
-Field name                        | Relationship | Field Name
-----------------------------------|:------------:|------------
-each quantity value               | >=           | 0
+| Field name          | Relationship | Field Name |
+|---------------------|:------------:|------------|
+| each quantity value |      >=      | 0          |
 
 ##### Example
 
@@ -281,10 +281,10 @@ each quantity value               | >=           | 0
 A composition represented as a chemical formula string.
 The order and grouping of the elements is ignored.
 
-Field name      | Value type | Description
-----------------|------------|------------
-`type`          | String     | "empirical\_formula"
-`formula`       | String     | Chemical formula to be parsed as an empirical formula
+| Field name | Value type | Description                                           |
+|------------|------------|-------------------------------------------------------|
+| `type`     | String     | "empirical\_formula"                                  |
+| `formula`  | String     | Chemical formula to be parsed as an empirical formula |
 
 
 ##### Example
@@ -316,10 +316,10 @@ We support two ways of representing a molecular structure:
 
 A value containing a [SMILES string](https://en.wikipedia.org/wiki/Simplified_molecular-input_line-entry_system).
 
-Field name      | Value type | Description
-----------------|------------|------------
-`type`          | String     | "smiles"
-`smiles`        | String     | A SMILES string
+| Field name | Value type | Description     |
+|------------|------------|-----------------|
+| `type`     | String     | "smiles"        |
+| `smiles`   | String     | A SMILES string |
 
 
 ##### Example
@@ -336,10 +336,10 @@ Field name      | Value type | Description
 A value containing an [InChI string](https://en.wikipedia.org/wiki/International_Chemical_Identifier).
 Note: this is not the same as the InChI key.
 
-Field name      | Value type | Description
-----------------|------------|------------
-`type`          | String     | "inchi"
-`inchi`         | String     | An InChI string
+| Field name | Value type | Description     |
+|------------|------------|-----------------|
+| `type`     | String     | "inchi"         |
+| `inchi`    | String     | An InChI string |
 
 
 ##### Example


### PR DESCRIPTION
The typo is hard to find with the formatting. See https://github.com/CitrineInformatics/taurus-documentation/compare/bug/PLA-2252-nominal-composition?expand=1#diff-c69fcd653a8ab771bf254220e073dd4eL11

The table formatting is done via the VSCode Markdown Table Formatter.