### PR TITLE
The scope field in a custom scope:id pair can't contain the delimiter string "::"

### DIFF
--- a/docs/specification/unique-identifiers.md
+++ b/docs/specification/unique-identifiers.md
@@ -22,7 +22,7 @@ Scope | Value type | Description
 
 ##### Constraints
 
-Field name | Relationship | Description
+Field name | Relationship | Constraint
 -----------|:------------:|------------
 len(`id`)  | ==           | 36
 `id`       | parses to    | Version 4 Random UUID
@@ -48,7 +48,7 @@ Field name | Value type | Description
 
 ##### Constraints
 
-Field name  | Relationship | Description
+Field name  | Relationship | Constraint
 ------------|:------------:|------------
 len(`uids`) |      <=      | 8
 len(`scope`)|      <=      | 128, UTF-8 encoded

--- a/docs/specification/unique-identifiers.md
+++ b/docs/specification/unique-identifiers.md
@@ -22,7 +22,7 @@ Scope | Value type | Description
 
 ##### Constraints
 
-Field name | Relationship | Field Name
+Field name | Relationship | Description
 -----------|:------------:|------------
 len(`id`)  | ==           | 36
 `id`       | parses to    | Version 4 Random UUID
@@ -48,11 +48,13 @@ Field name | Value type | Description
 
 ##### Constraints
 
-Field name  | Relationship | Field Name
+Field name  | Relationship | Description
 ------------|:------------:|------------
-len(`uids`) | <=           | 8
-len(`scope`)| <=           | 128, UTF-8 encoded
-len(`id`)   | <=           | 512, UTF-8 encoded
+len(`uids`) |      <=      | 8
+len(`scope`)|      <=      | 128, UTF-8 encoded
+len(`id`)   |      <=      | 512, UTF-8 encoded
+`scope`     |              | cannot include "::"
+
 
 ##### Example
 
@@ -62,6 +64,18 @@ len(`id`)   | <=           | 512, UTF-8 encoded
         "NIST-SRM" : "141e"
     }
 }
+```
+
+##### Invalid Example
+This scope field is not allowed by the Citrine Platform:
+
+```javascript
+{
+    "uids": {
+        "NIST::SRM" : "141e"
+    }
+}
+
 ```
 
 ---

--- a/docs/specification/unique-identifiers.md
+++ b/docs/specification/unique-identifiers.md
@@ -53,7 +53,7 @@ Field name  | Relationship | Description
 len(`uids`) |      <=      | 8
 len(`scope`)|      <=      | 128, UTF-8 encoded
 len(`id`)   |      <=      | 512, UTF-8 encoded
-`scope`     |              | cannot include "::"
+`scope`     |              | cannot include `::`
 
 
 ##### Example


### PR DESCRIPTION
The scope field in a custom scope:id pair can't contain the delimiter string "::"

There is not a behavioral change to the custom scope field, this PR just fixes an omission in the docs. 

There is a behavioral change that prompted this update -- Users can now include "::" in a custom ID field, but the existing docs are framed around constraints, so I didn't call it out explicitly (see https://github.com/CitrineInformatics/platform-backend/pull/3003). 