### PR TITLE
Add a missing required 'type' in process_template example

### DIFF
--- a/docs/specification/object-templates.md
+++ b/docs/specification/object-templates.md
@@ -68,6 +68,7 @@ This is an example of a process template that has fully represented attribute te
         [
             {
                 "name" : "Oven Temperature",
+                "type" : "parameter_template",
                 "uids" : {"cookie_templates": "oven_temp"},
                 "tags" : ["oven_settings::temperature"],
                 "description" : "A template for valid temperature ranges for baking cookies. Below 328K you're not even pasteurizing the dough.",
@@ -88,6 +89,7 @@ This is an example of a process template that has fully represented attribute te
         [
             {
                 "name" : "Baking Time",
+                "type" : "parameter_template",
                 "uids" : {"cookie_templates": "oven_time"},
                 "tags" : ["oven_settings::duration"],
 
@@ -157,6 +159,7 @@ property templates | are unique within | properties
         [
             {
                 "uids" : {"cookie_templates" : "choc_chip_comp_01"},
+                "type" : "property_template",
                 "tags" : ["ingredients::cookies::nutsallowed"],
                 "name" : "Chocolate Chip Cookie Composition",
                 "description" : "Specifying the composition of the linked cookie",
@@ -240,6 +243,7 @@ condition templates | are unique within | conditions
             {
                 "uids" : {"cookie_templates": "hedonic_index_prop"},
                 "tags" : [],
+                "type" : "property_template",
                 "name" : "Chocolate Chip Cookie Hedonic Index",
                 "description" : "The allowable range for the hedonic index of chocolate chip cookies.",
                 "bounds" : {
@@ -263,6 +267,7 @@ condition templates | are unique within | conditions
                 "name" : "Cookie Temperature",
                 "uids" : {"cookie_templates": "cookie_eating_temp"},
                 "tags" : [],
+                "type" : "condition_template",
                 "description" : "A template for valid temperature ranges for eating cookies.",
                 "bounds" : {
                     "default_units" : "kelvin",
@@ -285,6 +290,7 @@ condition templates | are unique within | conditions
                 "name" : "Number of Cookies",
                 "uids" : {"cookie_templates": "cookie_count"},
                 "tags" : ["chocula"],
+                "type" : "parameter_template",
                 "description" : "A template for the number of cookies to eat for a hedonic index test.",
                 "bounds" : {
                     "type" : "integer_bounds",

--- a/docs/specification/objects.md
+++ b/docs/specification/objects.md
@@ -207,7 +207,7 @@ Same as `ProcessSpec`, but with the `template` inherited from the `spec`, i.e., 
     ],
     "name" : "Bake Cookies Fo' Real",
     "notes" : "Process Run baking some chocolate chip cookies in an oven",
-    "process_spec" : {
+    "process" : {
         "type" : "link_by_uid",
         "scope" : "id",
         "id" : "064148e6-1cce-4d89-bfde-7ecd0aa4632b"
@@ -548,7 +548,7 @@ process | must be unique | globally
             }
         }
     }],
-    "process_spec" : {
+    "process" : {
         "type" : "link_by_uid",
         "scope" : "id",
         "id" : "064148e6-1cce-4d89-bfde-7ecd0aa4632b"

--- a/docs/specification/objects.md
+++ b/docs/specification/objects.md
@@ -414,7 +414,12 @@ material.spec | = | spec.material
         "type" : "normal_real",
         "mean" : 0.347,
         "std" : 0.002
-    }
+    },
+    "spec": {
+        "type" : "link_by_uid",
+        "scope" : "id",
+        "id" : "28d95397-4887-48f0-bdda-94a9a4c5ef43"
+    },
 }
 ```
 

--- a/docs/specification/objects.md
+++ b/docs/specification/objects.md
@@ -749,12 +749,12 @@ condition templates | must be unique | among the templates of conditions
     },
     "name" : "Chocolate Chip Hedonic Measurement",
     "notes" : "Rate the cookies on a scale from 9.9-10",
-    "measurement_spec" : {
+    "spec" : {
         "type" : "link_by_uid",
         "scope" : "cookie_ids",
         "id" : "choc_chip_hedonic_spec"
     },
-    "material_run" : {
+    "material" : {
         "type" : "link_by_uid",
         "scope" : "cookie_ids",
         "id": "choc_chip_001_run_006"


### PR DESCRIPTION
1. As per https://citrineinformatics.github.io/gemd-docs/specification/attribute-templates/ `type` is a required property of `parameter_template`.

2. Examples for `process_run` and `material_spec` were inconsistent with their definition. Both of them were using `process_spec` property, instead of `process`.

3. Example `ingredient_run` was missing a required `spec` property.

4. Example `measurement_run` was using wrong properties: `measurement_spec` and `material_run` instead of `spec` and `material` respectively.